### PR TITLE
Fix of https://github.com/algolia/algoliasearch-laravel/issues/22

### DIFF
--- a/src/AlgoliaEloquentTrait.php
+++ b/src/AlgoliaEloquentTrait.php
@@ -122,15 +122,18 @@ trait AlgoliaEloquentTrait
         }
     }
 
+    /**
+     * @param $method
+     * @param $parameters
+     * @return mixed
+     */
     public static function __callStatic($method, $parameters)
     {
         $instance = new static();
-
-        $method = '_'.$method;
-
-        if (method_exists($instance, $method));
-
-        return call_user_func_array([$instance, $method], $parameters);
+        $overload_method = '_'.$method;
+        if (method_exists($instance, $overload_method)) {
+            return call_user_func_array([$instance, $overload_method], $parameters);
+        }
 
         return parent::__callStatic($method, $parameters);
     }


### PR DESCRIPTION
Fixes the broken conditional and prevents the local overload method from being called if it does not exist in the class.