### PR TITLE
Do not publish files from other packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ AlgoliaSearch\Laravel\AlgoliaServiceProvider::class
 Laravel Algolia requires a connection configuration. To get started, you'll need to publish all vendor assets:
 
 ```bash
-php artisan vendor:publish
+php artisan vendor:publish --provider="Vinkla\Algolia\AlgoliaServiceProvider"
 ```
 
 This will create a `config/algolia.php` file in your app that you can modify to set your configuration. Also, make sure you check for changes compared to the original config file after an upgrade.


### PR DESCRIPTION
Calling `php artisan vendor:publish` will publish all unpublished assets from all other installed packages.