### PR TITLE
Update EloquentSubscriber.php

### DIFF
--- a/src/EloquentSubscriber.php
+++ b/src/EloquentSubscriber.php
@@ -35,7 +35,7 @@ class EloquentSubscriber
 
         /** @var \AlgoliaSearch\Index $index */
         foreach ($this->modelHelper->getIndices($model) as $index) {
-            $index->deleteObject($model->id);
+            $index->deleteObject($model->getObjectId());
         }
 
         return true;


### PR DESCRIPTION
In order to properly delete an object from Algolia, the subscriber must use the $model->getObjectId() method to account for tables that have primary keys labeled something other than "id". For example, "user_id".