### PR TITLE
Do a deep search when checking for traits

### DIFF
--- a/src/ModelHelper.php
+++ b/src/ModelHelper.php
@@ -19,9 +19,30 @@ class ModelHelper
         return $model->getTable();
     }
 
-    private function hasAlgoliaTrait(Model $model)
+    private function hasAlgoliaTrait(Model $class, $autoload = false)
     {
-        return (isset(class_uses($model)['AlgoliaSearch\Laravel\AlgoliaEloquentTrait']));
+        $traits = [];
+
+        // Get traits of all parent classes
+        do {
+            $traits = array_merge(class_uses($class, $autoload), $traits);
+        } while ($class = get_parent_class($class));
+
+        // Get traits of all parent traits
+        $traitsToSearch = $traits;
+        while (!empty($traitsToSearch)) {
+            $newTraits = class_uses(array_pop($traitsToSearch), $autoload);
+            $traits = array_merge($newTraits, $traits);
+            $traitsToSearch = array_merge($newTraits, $traitsToSearch);
+        };
+
+        foreach ($traits as $trait => $same) {
+            $traits = array_merge(class_uses($trait, $autoload), $traits);
+        }
+
+        $traits = array_unique($traits);
+
+        return (isset($traits['AlgoliaSearch\Laravel\AlgoliaEloquentTrait']));
     }
 
     public function isAutoIndex(Model $model)

--- a/tests/ModelHelperTest.php
+++ b/tests/ModelHelperTest.php
@@ -7,6 +7,7 @@ use AlgoliaSearch\Tests\Models\Model2;
 use AlgoliaSearch\Tests\Models\Model3;
 use AlgoliaSearch\Tests\Models\Model4;
 use AlgoliaSearch\Tests\Models\Model5;
+use AlgoliaSearch\Tests\Models\Model7;
 use Orchestra\Testbench\TestCase;
 
 class ModelHelperTest extends TestCase
@@ -27,10 +28,12 @@ class ModelHelperTest extends TestCase
         $this->assertEquals(true, $this->modelHelper->isAutoIndex(new Model1()));
         $this->assertEquals(false, $this->modelHelper->isAutoIndex(new Model2()));
         $this->assertEquals(false, $this->modelHelper->isAutoIndex(new Model3()));
+        $this->assertEquals(true, $this->modelHelper->isAutoIndex(new Model7()));
 
         $this->assertEquals(true, $this->modelHelper->isAutoDelete(new Model1()));
         $this->assertEquals(false, $this->modelHelper->isAutoDelete(new Model2()));
         $this->assertEquals(false, $this->modelHelper->isAutoDelete(new Model3()));
+        $this->assertEquals(true, $this->modelHelper->isAutoDelete(new Model7()));
     }
 
     public function testGetKey()

--- a/tests/Models/Model7.php
+++ b/tests/Models/Model7.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace AlgoliaSearch\Tests\Models;
+
+use AlgoliaSearch\Tests\Traits\Trait1;
+use Illuminate\Database\Eloquent\Model;
+
+class Model7 extends Model
+{
+    use Trait1;
+}

--- a/tests/Traits/Trait1.php
+++ b/tests/Traits/Trait1.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace AlgoliaSearch\Tests\Traits;
+
+use AlgoliaSearch\Laravel\AlgoliaEloquentTrait;
+
+trait Trait1
+{
+	use AlgoliaEloquentTrait;
+}


### PR DESCRIPTION
Consider the following. 

I want all my models to have the `$perEnvironment` property set to true. To avoid redundancy, I create my own trait that uses the Algolia trait.

```php
<?php

namespace App\Services;

use AlgoliaSearch\Laravel\AlgoliaEloquentTrait;

trait SearchIndexerTrait
{
	use AlgoliaEloquentTrait;

    public static $perEnvironment = true;
}
```

And so now I can just use my custom trait in all my models.

```php
<?php

namespace App;

use Illuminate\Database\Eloquent\Model;
use App\Services\SearchIndexerTrait;

class Product extends Model
{
    use SearchIndexerTrait;

    public $algoliaSettings = [
        'attributesToIndex' => [
            'name',
            'text',
        ],
        'attributesToRetrieve' => [
            'name',
            'text',
        ],
        'customRanking' => [
            'asc(name)',
        ],
    ];
}

```

However, my indices will no longer sync when I update or delete a model.

This is because `AlgoliaSearch\Laravel\EloquentSubscriber` uses the php `class_uses()` helper method on the currently updated Model to check if it uses the `AlgoliaEloquentTrait` in order to determine whether or not the index should be updated. `class_uses()` only checks the "top level" traits that are used. It does not check the parents traits, or traits inside traits.

To fix the problem, I used [this handy fucntion](http://php.net/manual/en/function.class-uses.php#112671). 

