### PR TITLE
Update AlgoliaEloquentTrait.php

### DIFF
--- a/src/AlgoliaEloquentTrait.php
+++ b/src/AlgoliaEloquentTrait.php
@@ -241,8 +241,8 @@ trait AlgoliaEloquentTrait
 
         $record = null;
 
-        if (method_exists($this, static::$methodGetName)) {
-            $record = $this->{static::$methodGetName}($indexName);
+        if (method_exists($this, self::$methodGetName)) {
+            $record = $this->{self::$methodGetName}($indexName);
         } else {
             $record = $this->toArray();
         }


### PR DESCRIPTION
See example below.

Call to static::$var fail when this trait is implemented on a parent model and the child is called.

```php
<?php

trait T {

    private static $traitVar = "trait";

    public function getTraitSelf() {
        return self::$traitVar;
    }

    public function getTraitStatic() {
        return static::$traitVar;
    }

}

class Person {
    use T;

}

class Guest extends Person {

}

echo (new Guest())->getTraitSelf()  . PHP_EOL; // Ok
echo (new Guest())->getTraitStatic() . PHP_EOL; // Fail
echo (new Person())->getTraitSelf()  . PHP_EOL; // Ok
echo (new Person())->getTraitStatic() . PHP_EOL; // Fail
```