### PR TITLE
Fix setSettings with synonyms (with clearSynonyms)

### DIFF
--- a/src/AlgoliaEloquentTrait.php
+++ b/src/AlgoliaEloquentTrait.php
@@ -173,9 +173,18 @@ trait AlgoliaEloquentTrait
             if (isset($settings['synonyms'])) {
                 $index->batchSynonyms($settings['synonyms'], true, true);
             }
+            else {
+                // If no synonyms are passed, clear all synonyms from index
+                $index->clearSynonyms(true);
+            }
 
             if (count(array_keys($settings)) > 0) {
-                $index->setSettings($settings);
+                // Synonyms cannot be pushed into "setSettings", it's got rejected from API and throwing exception
+                // Synonyms cannot be removed directly from $settings var, because then synonym would not be set to other indices
+                $settingsWithoutSynonyms = $settings;
+                unset($settingsWithoutSynonyms['synonyms']);
+
+                $index->setSettings($settingsWithoutSynonyms);
             }
 
             if ($b && isset($settings['slaves'])) {
@@ -189,6 +198,7 @@ trait AlgoliaEloquentTrait
                 $index = $modelHelper->getIndices($this, $slave)[0];
 
                 $s = array_merge($settings, $slaves_settings[$slave]);
+                unset($s['synonyms']);
 
                 if (count(array_keys($s)) > 0)
                     $index->setSettings($s);

--- a/tests/AlgoliaEloquentTraitTest.php
+++ b/tests/AlgoliaEloquentTraitTest.php
@@ -70,6 +70,7 @@ class AlgoliaEloquentTraitTest extends TestCase
         $index = Mockery::mock('\AlgoliaSearch\Index');
         $index->shouldReceive('setSettings')->with(['slaves' => ['model_6_desc_testing']]);
         $index->shouldReceive('setSettings')->with(['ranking' => ['desc(name)']]);
+        $index->shouldReceive('clearSynonyms');
 
         /** @var \AlgoliaSearch\Laravel\ModelHelper $realModelHelper */
         $realModelHelper = App::make('\AlgoliaSearch\Laravel\ModelHelper');


### PR DESCRIPTION
Fixes "[AlgoliaSearch\AlgoliaException] Invalid object inside settings near line:X column:Y" from setSettings method when synonyms were pushed to it.

Clears synonyms when no ones are pushed.
