### PR TITLE
Adds onInsert callback to reindex() static call.

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,17 @@ To keep settings that you set on the Algolia dashboard when reindexing and setti
 Contact::reindex(true, true, true);
 ```
 
+To implement a callback that gets called everytime a batch of entities is indexed:
+
+```php
+Contact::reindex(true, true, false, function ($entities)
+{
+    foreach ($entities as $entity)
+    {
+        var_dump($entity->id); // Contact::$id
+    }
+});
+```
 
 ### Clearing an Index
 

--- a/src/AlgoliaEloquentTrait.php
+++ b/src/AlgoliaEloquentTrait.php
@@ -33,19 +33,24 @@ trait AlgoliaEloquentTrait
         static::chunk(100, function ($models) use ($indicesTmp, $modelHelper, $onInsert) {
             /** @var \AlgoliaSearch\Index $index */
             foreach ($indicesTmp as $index) {
-                $records = [];
+                $records         = [];
+                $recordsAsEntity = [];
 
                 foreach ($models as $model) {
                     if ($modelHelper->indexOnly($model, $index->indexName)) {
                         $records[] = $model->getAlgoliaRecordDefault($index->indexName);
 
                         if ($onInsert && is_callable($onInsert)) {
-                            call_user_func_array($onInsert, [$model]);
+                            $recordsAsEntity[] = $model;
                         }
                     }
                 }
 
                 $index->addObjects($records);
+
+                if ($onInsert && is_callable($onInsert)) {
+                    call_user_func_array($onInsert, [$recordsAsEntity]);
+                }
             }
 
         });


### PR DESCRIPTION
Allows the usage of a callback in reindex() static call to access exactly which entity is being indexed to Algolia.

It's very easy, instead of using:

```php
Model::reindex(true, true);
```

You use:

```php
Model::reindex(true, true, function ($entities) { 
    foreach ($entities as $entity) {
        var_dump($entity->id); // entity id
    }
});
```

This way you perform operations on every single entity that is being indexed, for example updating the timestamp of an entity with the last indexing timestamp.