### PR TITLE
composer.json bug fix and getIndicesTmp bug fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,9 +8,7 @@
         "search",
         "api"
     ],
-    "abandoned": {
-      "algolia/algoliasearch-laravel": "laravel/scout"
-    },
+    "abandoned": "laravel/scout",
     "require": {
     	"php": ">=5.5.9",
         "vinkla/algolia": "~2.0"

--- a/src/ModelHelper.php
+++ b/src/ModelHelper.php
@@ -150,15 +150,9 @@ class ModelHelper
         return [$this->getIndexName($model)];
     }
 
-    public function getIndicesTmp(Model $model)
+    public function getIndicesTmp(Model $model, $indexName = null)
     {
-        $indicesName = [];
-
-        if (property_exists($model, 'indices') && is_array($model->indices)) {
-            $indicesName = $model->indices;
-        } else {
-            $indicesName[] = $this->getIndexName($model);
-        }
+        $indicesName = $this->buildIndices($model, $indexName);
 
         $indices = array_map(function ($index_name) use ($model) {
             return $this->algolia->initIndex($this->getFinalIndexName($model, $index_name).'_tmp');

--- a/tests/ModelHelperTest.php
+++ b/tests/ModelHelperTest.php
@@ -84,4 +84,20 @@ class ModelHelperTest extends TestCase
         $this->assertCount(2, $indices);
         $this->assertEquals('index1', $indices[0]->indexName);
     }
+
+    public function testGetIndicesTmp()
+    {
+        $this->assertEquals('model1s_tmp', $this->modelHelper->getIndicesTmp(new Model1())[0]->indexName);
+        $this->assertEquals('model5s_testing_tmp', $this->modelHelper->getIndicesTmp(new Model5())[0]->indexName);
+        $this->assertEquals('test_tmp', $this->modelHelper->getIndicesTmp(new Model1(), 'test')[0]->indexName);
+        $this->assertEquals('test_testing_tmp', $this->modelHelper->getIndicesTmp(new Model5(), 'test')[0]->indexName);
+        $this->assertEquals('model4s_tmp', $this->modelHelper->getIndicesTmp(new Model4())[0]->indexName);
+        $this->assertEquals('test_tmp', $this->modelHelper->getIndicesTmp(new Model14())[0]->indexName);
+        $this->assertEquals('override_tmp', $this->modelHelper->getIndicesTmp(new Model14(), 'override')[0]->indexName);
+
+        $indicesTmp = $this->modelHelper->getIndicesTmp(new Model2());
+
+        $this->assertCount(2, $indicesTmp);
+        $this->assertEquals('index1_tmp', $indicesTmp[0]->indexName);
+    }
 }


### PR DESCRIPTION
Hi there, I appreciate that this project has been deprecated but I have come across two issues that I was hoping you would merge.

**Composer.json bug**
The `abandoned` property was added to the `composer.json` file in 08e22a however according to the Composer spec this property must either be a boolean or a string. This PR fixes this.

Composer spec ref: https://github.com/composer/composer/blob/master/res/composer-schema.json#L513-L516

This can also be seen in the Travis CI build failures: https://travis-ci.org/algolia/algoliasearch-laravel/jobs/256789397

**getIndicesTmp bug fix**
Support for dynamically computed set of indices was added in ba65872, however, it was not also added to the `getIndicesTmp()` method which is used when bulk re-indexing. This breaks when you have multiple indices. This PR fixes this issue